### PR TITLE
Add support for gulp-rev & laravel mix versioning

### DIFF
--- a/classes/FingerprintFile.php
+++ b/classes/FingerprintFile.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Bnomei;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Http\Url;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\F;
+use Kirby\Toolkit\Str;
 use function dirname;
 use function filemtime;
 use function url;
@@ -96,6 +98,10 @@ final class FingerprintFile
                     $url = preg_replace('/\/'. kirby()->language()->code() .'$/', '', kirby()->site()->url());
                 }
                 $url = str_replace($url, '', $this->id());
+
+                $hasLeadingSlash = Str::substr(array_keys($manifest)[0], 0, 1) === '/';
+                $url = Url::path($url, $hasLeadingSlash);
+
                 $filename = basename(A::get(
                     $manifest,
                     $url,


### PR DESCRIPTION
This commit fixes #25

I tested this setup with a fresh starterkit and these two `manifest.json` files (one with leading slashes representing `mix-manifest.json` and one without leading slashes representing what `gulp-rev` outputs):

```json
{
  "/assets/css/index.css": "/assets/css/index-83e06e8ea7.css",
  "/assets/css/lightbox.css": "/assets/css/lightbox-83e06e8ea7.css",
  "/assets/css/prism.css": "/assets/css/prism-83e06e8ea7.css",
  "/assets/js/index.js": "/assets/js/index-8f550e0370.js",
  "/assets/js/lightbox.js": "/assets/js/lightbox-8f550e0370.js",
  "/assets/js/prism.js": "/assets/js/prism-8f550e0370.js"
}
```

and

```json
{
  "assets/css/index.css": "assets/css/index-83e06e8ea7.css",
  "assets/css/lightbox.css": "assets/css/lightbox-83e06e8ea7.css",
  "assets/css/prism.css": "assets/css/prism-83e06e8ea7.css",
  "assets/js/index.js": "assets/js/index-8f550e0370.js",
  "assets/js/lightbox.js": "assets/js/lightbox-8f550e0370.js",
  "assets/js/prism.js": "assets/js/prism-8f550e0370.js"
}
```

When trying to `A::get` the `$url` value from `$manifest`, you are passing the complete URL instead of the URL path that's saved as array key. Thus, we first check if the first array key comes with leading slash or not and use that instead, using Kirby's `URL::path` method.

It works for all scenarios as far as I can see now.

One thing: the README could use a hint about using the `ready` function if you want to use `kirby()->root()` function for a manifest file not in the public area - otherwise:

```php
return [
    # works
    'bnomei.fingerprint.query' => 'assets/manifest.json',
    # does not work
    'bnomei.fingerprint.query' => '/assets/manifest.json',
];
```

Please consider testing & merging this, otherwise tell me how it could've worked before - I didn't get it to work, using `gulp-rev` on my end.

Cheers and all the best, your admirer
S1SYPHOS