### PR TITLE
Fix `manifest.json` base file not existing

### DIFF
--- a/classes/FingerprintFile.php
+++ b/classes/FingerprintFile.php
@@ -85,10 +85,6 @@ final class FingerprintFile
     {
         $root = $this->fileRoot();
 
-        if (! F::exists($root)) {
-            return url($this->file);
-        }
-
         $filename = null;
         if (is_string($query) && F::exists($query)) {
             $manifest = json_decode(F::read($query), true);
@@ -109,6 +105,10 @@ final class FingerprintFile
                 ));
             }
         } elseif (is_bool($query)) {
+            if (! F::exists($root)) {
+                return url($this->file);
+            }
+
             $filename = implode('.', [
                 F::name($root),
                 $query ? F::extension($root) . '?v=' . filemtime($root) : md5_file($root) . '.' . F::extension($root)
@@ -143,7 +143,7 @@ final class FingerprintFile
                 // https://www.srihash.org/
                 $data = file_get_contents($root);
                 $digest_sha384 = openssl_digest($data, "sha384", true);
-                if($digest_sha384){
+                if ($digest_sha384) {
                     $output = base64_encode($digest_sha384);
                     return 'sha384-' . $output;
                 }
@@ -153,8 +153,7 @@ final class FingerprintFile
             if (is_array($output) && count($output) >= 1) {
                 return 'sha384-' . $output[0];
             }
-        } catch (\Exception $ex) {
-        }
+        } catch (\Exception $ex) {}
 
         return null; // @codeCoverageIgnore
     }


### PR DESCRIPTION
This fixes the following scenario:

You got the usual `manifest.json`:

```json
{
  "assets/scripts/main.js": "assets/scripts/main.2c9fbee0.js",
  "assets/styles/main.css": "assets/styles/main.918351a2.css"
}
```

Now, if `assets/scripts/main.js` doesn't exist (because you already renamed it to `assets/scripts/main.2c9fbee0.js`), the current setup fails (no cache-busting), while the `elseif` check relies on `$root` being an actual file (if `true`, it's using `filemtime`, otherwise `md5_file`) - therefore, the `! F::exists()` check should go there.

If neither `string` nor `bool` but `callback`: we don't care whether it exists or not: it's used inside `dirname` at the end of the `hash` function, which doesn't concern us, although we *could* think about checking whether `$filename`exists in the `else` block I guess. Creating a test for this scenario frankly escapes me right now :fox_face: 

**// Update:** The library I used is @johannschopplich's [`hashup`](https://github.com/johannschopplich/hashup) which renames assets on-the-fly, so *it's a thing*!