### PR TITLE
fix: dont emit @auto css link if template asset does not exist

### DIFF
--- a/classes/Fingerprint.php
+++ b/classes/Fingerprint.php
@@ -140,6 +140,8 @@ final class Fingerprint
             $assetUrl = Url::toTemplateAsset($extension.'/templates', $extension);
             if ($assetUrl) {
                 $url = $assetUrl;
+            } else {
+                return null;
             }
         }
 


### PR DESCRIPTION
If `css_f('@auto')` or `js_f('@auto')` is used on a site that has no template asset, a link or script tag with `…/@auto` as the URL is generated. With this pull request, no HTML tag would be emitted instead. This way, no HTML tag with an invalid URL would be emitted.